### PR TITLE
Made EddystoneEncryptedTLMFrame str printable.

### DIFF
--- a/beacontools/packet_types/eddystone.py
+++ b/beacontools/packet_types/eddystone.py
@@ -90,7 +90,7 @@ class EddystoneEncryptedTLMFrame(object):
 
     def __str__(self):
         return "EddystoneEncryptedTLMFrame<encrypted_data: %s, salt: %d, mic: %d>" \
-               % (self.encrypted_data, self.salt, self.mic)
+               % (hexlify(self.encrypted_data), self.salt, self.mic)
 
 
 class EddystoneTLMFrame(object):


### PR DESCRIPTION
Previously I'd get exceptions like

    UnicodeDecodeError: 'ascii' codec can't decode byte 0xf2 in position 43: ordinal not in range(128)

when trying to print received frames.